### PR TITLE
Chef-18 migration spike 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/chef-rvm.iml
+++ b/.idea/chef-rvm.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Remote: ruby-2.7.6-p219" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/chef-rvm.iml" filepath="$PROJECT_DIR$/.idea/chef-rvm.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,11 +58,11 @@ default['rvm']['gpg_key']       = '409B6B1796C275462A1703113804BB82D39DC0E3 7D2B
 
 case node["platform_version"]
 when "redhat","centos","fedora","scientific","amazon"
-  node.set['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git}
+  node.default['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git}
 when "debian","ubuntu","suse"
-  node.set['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git-core}
+  node.default['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git-core}
 when "gentoo"
-  node.set['rvm']['install_pkgs']   = %w{git}
+  node.default['rvm']['install_pkgs']   = %w{git}
 when "mac_os_x", "mac_os_x_server"
-  node.set['rvm']['install_pkgs']   = %w{git}
+  node.default['rvm']['install_pkgs']   = %w{git}
 end

--- a/libraries/provider_rvm_installation.rb
+++ b/libraries/provider_rvm_installation.rb
@@ -104,7 +104,7 @@ class Chef
       end
 
       def run_install_cmd
-        rvm_shell_out!(%{bash #{rvm_installer_path} #{new_resource.installer_flags}})
+        rvm_shell_out!(%{/bin/bash #{rvm_installer_path} #{new_resource.installer_flags}})
       end
 
       def rvm_installer_path

--- a/libraries/provider_rvm_installation.rb
+++ b/libraries/provider_rvm_installation.rb
@@ -104,7 +104,7 @@ class Chef
       end
 
       def run_install_cmd
-        rvm_shell_out!(%{/bin/bash #{rvm_installer_path} #{new_resource.installer_flags}})
+        rvm_shell_out!(%{bash #{rvm_installer_path} #{new_resource.installer_flags}})
       end
 
       def rvm_installer_path
@@ -151,7 +151,8 @@ class Chef
         }
 
         Chef::Log.debug("Running [#{cmd}] with #{opts}")
-        shell_out(cmd, opts)
+        # Chef 18 shell_out needs explicit shell invocation when using options
+        shell_out("/bin/bash", "-c", cmd, opts)
       end
 
       def rvm_shell_out!(*args)

--- a/libraries/provider_rvm_installation.rb
+++ b/libraries/provider_rvm_installation.rb
@@ -114,10 +114,13 @@ class Chef
       end
 
       def installed?
+        return false unless ::File.exist?("#{rvm_path}/scripts/rvm")
         cmd = rvm_shell_out(
           %{bash -c "source #{rvm_path}/scripts/rvm && type rvm"}
         )
         (cmd.exitstatus == 0 && cmd.stdout.lines.first == "rvm is a function\n")
+      rescue Errno::ENOENT
+        false
       end
 
       def version

--- a/libraries/resource_rvm_installation.rb
+++ b/libraries/resource_rvm_installation.rb
@@ -26,6 +26,7 @@ class Chef
   class Resource
 
     class RvmInstallation < Chef::Resource
+      provides :rvm_installation
 
       state_attrs :installed, :version
 

--- a/libraries/rvm_chef_user_environment.rb
+++ b/libraries/rvm_chef_user_environment.rb
@@ -23,13 +23,18 @@ def create_rvm_chef_user_environment
   klass = Class.new(::RVM::Environment) do
     attr_reader :user, :source_environment
 
+    # Use class instance variable instead of class variable for Ruby 3.x compatibility
+    class << self
+      attr_accessor :root_rvm_path
+    end
+
     def initialize(user = nil, environment_name = "default", options = {})
       @source_environment = options.delete(:source_environment)
       @source_environment = true if @source_environment.nil?
       @user = user
       # explicitly set rvm_path if user is set
       if @user.nil?
-        config['rvm_path'] = @@root_rvm_path
+        config['rvm_path'] = self.class.root_rvm_path
       else
         config['rvm_path'] = File.join(Etc.getpwnam(@user).dir, '.rvm')
       end
@@ -43,10 +48,6 @@ def create_rvm_chef_user_environment
           use_rvm_environment
         end
       end
-    end
-
-    def self.root_rvm_path=(path)
-      @@root_rvm_path = path
     end
   end
   ::RVM.const_set('ChefUserEnvironment', klass)

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -40,8 +40,8 @@ class Chef
           ENV['PATH'] = '' if ENV['PATH'].nil?
           paths = (ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin))
           paths.each do |path|
-            possible = File.join(path, cmd)
-            return possible if File.executable?(possible)
+            possible = ::File.join(path, cmd)
+            return possible if ::File.executable?(possible)
           end
           nil
         end

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -33,6 +33,18 @@ class Chef
     class Package
       class RVMRubygems < Chef::Provider::Package::Rubygems
         include Chef::RVM::ShellHelpers
+
+        # Fix for apt cookbook's which method conflict with Chef 18
+        # apt cookbook defines which(cmd) with 1 arg but Chef 18 calls it with 2
+        def which(cmd, *args)
+          ENV['PATH'] = '' if ENV['PATH'].nil?
+          paths = (ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin))
+          paths.each do |path|
+            possible = File.join(path, cmd)
+            return possible if File.executable?(possible)
+          end
+          nil
+        end
         include Chef::RVM::SetHelpers
 
         class RVMGemEnvironment < AlternateGemEnvironment

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -138,10 +138,14 @@ class Chef
           # ensure each ruby is installed and gemset exists
           ruby_strings.each do |rubie|
             next if rubie == 'system'
-            e = ::Chef::Resource::RvmEnvironment.new(rubie, @run_context)
-            e.user(gem_env.user) if gem_env.user
-            e.action(:nothing)
-            e.run_action(:create)
+            # Use declare_resource for Chef 18 compatibility
+            e = @run_context.resource_collection.find(rvm_environment: rubie) rescue nil
+            unless e
+              e = Chef::Resource.resource_for_node(:rvm_environment, @run_context.node).new(rubie, @run_context)
+              e.user(gem_env.user) if gem_env.user
+              e.action(:nothing)
+              e.run_action(:create)
+            end
           end
 
           install_via_gem_command(name, version)

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -162,7 +162,7 @@ class Chef
           end
 
           cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
-          cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
+          cmd << %{ install #{name} -q --no-document -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
           if gem_env.user

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.1"
+version           "0.11.2"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.4"
+version           "0.12.5"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.2"
+version           "0.12.3"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.0"
+version           "0.11.1"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.4"
+version           "0.11.5"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.5"
+version           "0.12.6"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.3"
+version           "0.11.4"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.2"
+version           "0.11.3"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.0"
+version           "0.12.1"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.11.5"
+version           "0.12.0"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.3"
+version           "0.12.4"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.1"
+version           "0.12.2"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.12.6"
+version           "1.0.0"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.10.3"
+version           "0.11.0"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -129,7 +129,8 @@ def install_ruby_dependencies(rubie)
   when /^ruby-/, /^ree-/, /^rbx-/, /^kiji/
     case node['platform']
       when "debian","ubuntu"
-        pkgs  = %w{ build-essential openssl libreadline6 libreadline6-dev
+        # Ubuntu 24+ uses libreadline-dev instead of libreadline6/libreadline6-dev
+        pkgs  = %w{ build-essential openssl libreadline-dev
                     zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev
                     sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
                     ncurses-dev automake libtool bison ssl-cert pkg-config libgdbm-dev libffi-dev}

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -29,6 +29,7 @@ attribute :source,        :kind_of => String
 attribute :options,       :kind_of => Hash
 attribute :gem_binary,    :kind_of => String
 attribute :user,          :kind_of => String
+attribute :include_default_source, :kind_of => [TrueClass, FalseClass], :default => true
 
 def initialize(*args)
   super

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -30,6 +30,7 @@ attribute :options,       :kind_of => Hash
 attribute :gem_binary,    :kind_of => String
 attribute :user,          :kind_of => String
 attribute :include_default_source, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :environment,   :kind_of => Hash
 
 def initialize(*args)
   super


### PR DESCRIPTION
During spike of migration to higher versions of Ubuntu we also needed to check migration to Chef-18. Here are some artefacts after that
[Notions notes](https://www.notion.so/u2i/Ubuntu-Upgrade-Spike-2dff852a7a4a80c497f8fbbd7e9055ad?source=copy_link#2fef852a7a4a8089b933f7855912664a)
Generated with usage of AI